### PR TITLE
Fix AT+LADV

### DIFF
--- a/ATinterface/$LIB$.AT.interface.sb
+++ b/ATinterface/$LIB$.AT.interface.sb
@@ -1770,7 +1770,7 @@ endsub
 // BLE advertising for central devices to connect to for VSP service
 //------------------------------------------------------------------------------
 sub IdleStartAdverts(advType, adIntervalMs)
-    rc = BleAdvertStart(advType, emptyAddr$, idleAdvIntvlMs , ADV_DURATION_FOREVER, ADV_FILTER_NONE)
+    rc = BleAdvertStart(advType, emptyAddr$, adIntervalMs , ADV_DURATION_FOREVER, ADV_FILTER_NONE)
     #cmpif 0x00000003 : AssertRC(1758)
     #cmpif 0x00000004 : DbgMsg("Idle Adverts Started")
     if rc == 0 then


### PR DESCRIPTION
`IdleStartAdverts` wasn't using its argument and instead used the cached value.
AT+LADV would need to be executed twice in order for the advertisement rate to change.